### PR TITLE
Fix: update job configuration route relaunch job with new configuration

### DIFF
--- a/cronjob/dbUpdateJob.js
+++ b/cronjob/dbUpdateJob.js
@@ -1,86 +1,17 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
-import { exec } from "child_process";
-import { jobConfiguration } from "../src/models/JobConfiguration/JobConfiguration.model";
-import { FrequencyEnum } from "../src/utils/enums/frequencyEnum";
+import Job from "./job";
 
-const { config } = require("dotenv");
-config();
-// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
-const cron = require("node-cron");
-// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
-const mongoose = require("mongoose");
+class DbUpdateJob extends Job {
+  constructor(jobName) {
+    super(jobName);
 
-const job = () => {
-  // Construct the MongoDB URI
-  // eslint-disable-next-line no-undef
-  let mongoUri = `mongodb://${process.env.MONGO_HOST}:${process.env.MONGO_PORT}/${process.env.MONGO_DATABASE}`;
+    // SINGLETON
+    if (!DbUpdateJob.instance) {
+      this.getConfiguration().then(() => this.start());
+      DbUpdateJob.instance = this;
+    }
 
-  // Append username and password if available
-  // eslint-disable-next-line no-undef
-  if (process.env.MONGO_USERNAME && process.env.MONGO_PASSWORD) {
-    // eslint-disable-next-line no-undef
-    mongoUri = `mongodb+srv://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@${process.env.MONGO_HOST}/${process.env.MONGO_DATABASE}`;
+    return DbUpdateJob.instance;
   }
+}
 
-  // Connect to the MongoDB database
-  mongoose
-    .connect(mongoUri, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    })
-    .then(async () => {
-      // eslint-disable-next-line no-console,no-undef
-      console.log(`dbUpdateJob Connected to MongoDB`);
-
-      const dbUpdateJobConfiguration = await jobConfiguration
-        .findOne({
-          job: "dbUpdateJob",
-        })
-        .exec();
-
-      // By default, every day at 4AM
-      let cronSchedule = "0 4 * * *";
-
-      if (dbUpdateJobConfiguration && dbUpdateJobConfiguration.scheduled) {
-        switch (dbUpdateJobConfiguration.frequency) {
-          case FrequencyEnum.DAILY:
-            cronSchedule = "0 4 * * *";
-            break;
-          // Every sunday at 4AM
-          case FrequencyEnum.WEEKLY:
-            cronSchedule = "0 4 * * SUN";
-            break;
-          // Every 1 of the month at 4 AM
-          case FrequencyEnum.MONTHLY:
-            cronSchedule = "0 4 1 * *";
-            break;
-          // every first of january
-          case FrequencyEnum.ANNUALLY:
-            cronSchedule = "0 4 1 1 *";
-            break;
-        }
-      }
-
-      cron.schedule(
-        cronSchedule,
-        () => {
-          exec("node ./scripts/dbUpdate.js", (error, stdout, stderr) => {
-            if (error) {
-              // eslint-disable-next-line no-console,no-undef
-              console.log(`error: ${error.message}`);
-              return;
-            }
-            // eslint-disable-next-line no-console,no-undef
-            console.log(`Job Launched successfully`);
-          });
-        },
-        {
-          scheduled: dbUpdateJobConfiguration?.scheduled ?? true,
-          // eslint-disable-next-line no-undef
-          timezone: process.env.JOB_TIMEZONE,
-        }
-      );
-    });
-};
-
-export default job;
+export default DbUpdateJob;

--- a/cronjob/job.js
+++ b/cronjob/job.js
@@ -1,0 +1,102 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
+import { exec } from "child_process";
+import { jobConfiguration } from "../src/models/JobConfiguration/JobConfiguration.model";
+import { FrequencyEnum } from "../src/utils/enums/frequencyEnum";
+
+const { config } = require("dotenv");
+config();
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
+const cron = require("node-cron");
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
+const mongoose = require("mongoose");
+
+class Job {
+
+  jobName;
+  cronSchedule = "0 4 * * *";
+  job;
+  dbUpdateJobConfiguration;
+
+  constructor(jobName) {
+    this.jobName = jobName;
+  }
+
+  async getConfiguration() {
+    return new Promise((resolve, reject) => {
+      let mongoUri = `mongodb://${process.env.MONGO_HOST}:${process.env.MONGO_PORT}/${process.env.MONGO_DATABASE}`;
+      // Append username and password if available
+      // eslint-disable-next-line no-undef
+      if (process.env.MONGO_USERNAME && process.env.MONGO_PASSWORD) {
+        // eslint-disable-next-line no-undef
+        mongoUri = `mongodb+srv://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@${process.env.MONGO_HOST}/${process.env.MONGO_DATABASE}`;
+      }
+
+      // Connect to the MongoDB database
+      mongoose
+        .connect(mongoUri, {
+          useNewUrlParser: true,
+          useUnifiedTopology: true,
+        })
+        .then(async () => {
+          // eslint-disable-next-line no-console,no-undef
+          this.dbUpdateJobConfiguration = await jobConfiguration
+            .findOne({
+              job: this.jobName,
+            })
+            .exec();
+
+          if (this.dbUpdateJobConfiguration && this.dbUpdateJobConfiguration.scheduled) {
+            console.log()
+            switch (this.dbUpdateJobConfiguration.frequency) {
+              // Every day at 4 AM
+              case FrequencyEnum.DAILY:
+                this.cronSchedule = "0 4 * * *";
+                break;
+              // Every sunday at 4AM
+              case FrequencyEnum.WEEKLY:
+                this.cronSchedule = "0 4 * * SUN";
+                break;
+              // Every 1 of the month at 4 AM
+              case FrequencyEnum.MONTHLY:
+                this.cronSchedule = "0 4 1 * *";
+                break;
+              // every first of january
+              case FrequencyEnum.ANNUALLY:
+                this.cronSchedule = "0 4 1 1 *";
+                break;
+            }
+          }
+          resolve();
+        }).catch(reject);
+    })
+  }
+
+  async start() {
+    await this.getConfiguration();
+    this.job = cron.schedule(
+      this.cronSchedule,
+      () => {
+        exec(`node ./scripts/${this.jobName}.js`, (error, stdout, stderr) => {
+          if (error) {
+            // eslint-disable-next-line no-console,no-undef
+            console.log(`error: ${error.message}`);
+            return;
+          }
+          // eslint-disable-next-line no-console,no-undef
+          console.log(`${this.constructor.name} Job Launched successfully`);
+        });
+      },
+      {
+        scheduled: this.dbUpdateJobConfiguration?.scheduled ?? true,
+        // eslint-disable-next-line no-undef
+        timezone: process.env.JOB_TIMEZONE,
+      }
+    );
+  }
+
+  stop() {
+    this.job.stop();
+  }
+}
+
+export default Job;

--- a/cronjob/job.js
+++ b/cronjob/job.js
@@ -46,7 +46,6 @@ class Job {
             .exec();
 
           if (this.dbUpdateJobConfiguration && this.dbUpdateJobConfiguration.scheduled) {
-            console.log()
             switch (this.dbUpdateJobConfiguration.frequency) {
               // Every day at 4 AM
               case FrequencyEnum.DAILY:

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import jobConfigurationSeed from "../seed/jobConfigurationSeed";
-import Job from "../../cronjob/dbUpdateJob";
+// @ts-ignore
+import DbUpdateJob from "../../cronjob/dbUpdateJob";
 
 export async function loadMongoose() {
   let mongoUri = `mongodb://${process.env.MONGO_HOST}:${process.env.MONGO_PORT}/${process.env.MONGO_DATABASE}`;
@@ -20,7 +21,7 @@ export async function loadMongoose() {
   await jobConfigurationSeed().then(() => {
     // Job lauch after succesfully seeded the database
     // temprarily here to not broke the unit tests
-    Job();
+    new DbUpdateJob("dbUpdate");
 
     console.log("Seed succeeded");
   });

--- a/src/controllers/jobConfigurations.ts
+++ b/src/controllers/jobConfigurations.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import { jobConfiguration } from "../models/JobConfiguration/JobConfiguration.model";
 import { FrequencyEnum } from "../utils/enums/frequencyEnum";
+// @ts-ignore
+import DbUpdateJob from "../../cronjob/dbUpdateJob";
 
 /**
  * Retrieves all configurations
@@ -59,6 +61,10 @@ export const updateJobConfiguration = async (
     const { job } = req.params;
     const { scheduled, frequency }: JobConfigurationUpdatePayload = req.body;
 
+    const cronJob = new DbUpdateJob("dbUpdate");
+
+    cronJob.stop();
+
     const data = await jobConfiguration.findOneAndUpdate(
       { job },
       { scheduled, frequency },
@@ -66,6 +72,8 @@ export const updateJobConfiguration = async (
         new: true,
       }
     );
+
+    await cronJob.start();
 
     return res.status(201).json(data);
   } catch (err) {

--- a/src/data/jobs.ts
+++ b/src/data/jobs.ts
@@ -1,1 +1,1 @@
-export const jobs = ["dbUpdateJob"];
+export const jobs = ["dbUpdate"];

--- a/src/middleware/jobConfigurationCheck.ts
+++ b/src/middleware/jobConfigurationCheck.ts
@@ -43,7 +43,7 @@ export const checkPayloadOnJobConfigurationUpdate = async (
     const body = req.body;
     const errors: string | any[] = [];
 
-    if (!(body.frequency in FrequencyEnum))
+    if (body.frequency && !(body.frequency in FrequencyEnum))
       throw new BadRequestError("frequency is not valid", [
         {
           field: "frequency",

--- a/src/seed/jobConfigurationSeed.ts
+++ b/src/seed/jobConfigurationSeed.ts
@@ -2,7 +2,7 @@ import { jobConfiguration } from "../models/JobConfiguration/JobConfiguration.mo
 import { FrequencyEnum } from "../utils/enums/frequencyEnum";
 
 const data = {
-  job: "dbUpdateJob",
+  job: "dbUpdate",
   scheduled: true,
   frequency: FrequencyEnum.DAILY,
 };


### PR DESCRIPTION
- Added a class named "Job" with all the logic to launch script in a cronjob
- Added a singleton class "DbUpdateJob" who extends Job
- At the update of the configuration the cronjob is stop and restart with the new configuration
- Now it's possible to run multiple Job at the same time, who run different script or the same
- Fixed the JobConfigurationCheck to only throw when the parameter "frequency" is in the query