### PR TITLE
fix: add env var to allow cron skip

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,6 @@ MONGO_HOST=catalog-registry-mongodb
 MONGO_DATABASE=catalog-registry
 API_URL=http://localhost:3000/v1
 JOB_TIMEZONE="Europe/Paris"
+
+# Allows skipping of the auto synchronization to the PTX Reference Models (true/false)
+SKIP_SYNC_CRON=false

--- a/cronjob/job.js
+++ b/cronjob/job.js
@@ -80,6 +80,8 @@ class Job {
     this.job = cron.schedule(
       this.cronSchedule,
       () => {
+        if (process.env.SKIP_SYNC_CRON == "true") return;
+
         // If instance.config.json exists don't run the db:update
 
         if (existsSync(path.join(__dirname, "..", "instance.config.json"))) {


### PR DESCRIPTION
Adds an environment variable to allow for the skipping of the cron job that synchronizes the registry with the PTX Reference Models. This is useful for custom instances that have their own data / service categories and do not want them to be overriden or enhanced with default PTX data / service categories.